### PR TITLE
Add Extended Mode for Scanning

### DIFF
--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -1503,7 +1503,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.12;
+				MARKETING_VERSION = 1.12.1;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1553,7 +1553,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.12;
+				MARKETING_VERSION = 1.12.1;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1669,7 +1669,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.12;
+				MARKETING_VERSION = 1.12.1;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1778,7 +1778,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 1.12;
+				MARKETING_VERSION = 1.12.1;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -1867,7 +1867,7 @@
 			repositoryURL = "git@github.com:rarimo/NFCPassportReader.git";
 			requirement = {
 				kind = revision;
-				revision = 9c1354d59148519340db448cd4c7aba852f5e8d9;
+				revision = deb4669a53d6351dc00787491b2b93f553ca4141;
 			};
 		};
 		56E7AD0F2BDBA81000D3A258 /* XCRemoteSwiftPackageReference "PullToRefreshSwiftUI" */ = {

--- a/Rarime.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rarime.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,7 +78,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:rarimo/NFCPassportReader.git",
       "state" : {
-        "revision" : "9c1354d59148519340db448cd4c7aba852f5e8d9"
+        "revision" : "deb4669a53d6351dc00787491b2b93f553ca4141"
       }
     },
     {

--- a/Rarime/Code/Modules/ScanPassport/Utils/NFCScanner.swift
+++ b/Rarime/Code/Modules/ScanPassport/Utils/NFCScanner.swift
@@ -42,6 +42,7 @@ class NFCScanner {
     static func scanPassport(
         _ mrzKey: String,
         _ challenge: Data,
+        _ useExtendedMode: Bool = true,
         onCompletion: @escaping (Result<Passport, Error>) -> Void
     ) {
         Task { @MainActor in
@@ -50,6 +51,7 @@ class NFCScanner {
                     .readPassport(
                         mrzKey: mrzKey,
                         tags: [.DG1, .DG2, .DG15, .SOD],
+                        useExtendedMode: useExtendedMode,
                         customDisplayMessage: customDisplayMessage,
                         activeAuthenticationChallenge: [UInt8](challenge)
                     )


### PR DESCRIPTION
# Problem

Sometimes, the messages exchanged by our NFC library are too short to hold all data.

# Solution

Try extended mode if a message is too short