### PR TITLE
Fix Reverse Tokens Conditions

### DIFF
--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 		CE9E82D72BA8917100AAF885 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9E82D62BA8917100AAF885 /* LottieView.swift */; };
 		CEA03F0A2C7C7A17002F218A /* View+IsLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F092C7C7A17002F218A /* View+IsLoading.swift */; };
 		CEA03F0C2C7C9319002F218A /* CreateIdentityIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */; };
-		CEB8B2792C6A29520029DD80 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8B2782C6A29520029DD80 /* Identity.xcframework */; };
+		CEA5934A2C80686800528448 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEA593492C80686800528448 /* Identity.xcframework */; };
 		CEB8B27C2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA2048.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8B27A2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA2048.a */; };
 		CEB8B27D2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA4096.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8B27B2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA4096.a */; };
 		CEB91BBE2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB91BBD2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift */; };
@@ -441,7 +441,7 @@
 		CE9E82E62BA89CE300AAF885 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		CEA03F092C7C7A17002F218A /* View+IsLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+IsLoading.swift"; sourceTree = "<group>"; };
 		CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIdentityIntroView.swift; sourceTree = "<group>"; };
-		CEB8B2782C6A29520029DD80 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
+		CEA593492C80686800528448 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEB8B27A2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA2048.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentityUniversalRSA2048.a; sourceTree = "<group>"; };
 		CEB8B27B2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA4096.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentityUniversalRSA4096.a; sourceTree = "<group>"; };
 		CEB91BBD2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NFCPassportModel+getDataGroupsRead.swift"; sourceTree = "<group>"; };
@@ -500,7 +500,6 @@
 				CEB8B27C2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA2048.a in Frameworks */,
 				CE61E8832C24240000940129 /* Semaphore in Frameworks */,
 				56E2D9322BD01E71006E725D /* NFCPassportReader in Frameworks */,
-				CEB8B2792C6A29520029DD80 /* Identity.xcframework in Frameworks */,
 				56933E082BBC09990068C894 /* QKMRZScanner in Frameworks */,
 				CE8FEB5C2C1AFC3F0008381A /* libwitnesscalc_auth.a in Frameworks */,
 				CE68BE472BD9B6EA00D92EBB /* Web3ContractABI in Frameworks */,
@@ -510,6 +509,7 @@
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
+				CEA5934A2C80686800528448 /* Identity.xcframework in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 				CEB8B27D2C6A35C30029DD80 /* libwitnesscalc_registerIdentityUniversalRSA4096.a in Frameworks */,
 			);
@@ -1147,7 +1147,7 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEB8B2782C6A29520029DD80 /* Identity.xcframework */,
+				CEA593492C80686800528448 /* Identity.xcframework */,
 				CE8FEB5B2C1AFC3F0008381A /* libwitnesscalc_auth.a */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562022BD923B4002D4954 /* libfq.a */,

--- a/Rarime/Code/Managers/PassportManager.swift
+++ b/Rarime/Code/Managers/PassportManager.swift
@@ -28,7 +28,7 @@ class PassportManager: ObservableObject {
     }
 
     var isUnsupportedForRewards: Bool {
-        UNSUPPORTED_REWARD_COUNTRIES.contains(passportCountry)
+        UNSUPPORTED_REWARD_COUNTRIES.contains(passportCountry) || passport?.isExpired ?? true
     }
 
     func setPassport(_ passport: Passport) {

--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -343,6 +343,8 @@ class UserManager: ObservableObject {
             startedAt: 1715688000
         )
         
+        LoggerUtil.common.debug("queryProofInputs: \(queryProofInputs.utf8)")
+        
         let wtns = try ZKUtils.calcWtnsQueryIdentity(queryProofInputs)
         
         let (proofJson, pubSignalsJson) = try ZKUtils.groth16QueryIdentity(wtns)

--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -343,8 +343,6 @@ class UserManager: ObservableObject {
             startedAt: 1715688000
         )
         
-        LoggerUtil.common.debug("queryProofInputs: \(queryProofInputs.utf8)")
-        
         let wtns = try ZKUtils.calcWtnsQueryIdentity(queryProofInputs)
         
         let (proofJson, pubSignalsJson) = try ZKUtils.groth16QueryIdentity(wtns)

--- a/Rarime/Code/Models/Passport.swift
+++ b/Rarime/Code/Models/Passport.swift
@@ -21,6 +21,14 @@ struct Passport: Codable {
     var fullName: String {
         "\(firstName) \(lastName)"
     }
+    
+    var isExpired: Bool {
+        if let expiryDate = try? DateUtil.parsePassportDate(documentExpiryDate) {
+            return expiryDate < Date()
+        } else {
+            return true
+        }
+    }
 
     var passportImage: UIImage? {
         guard let passportImageRaw = passportImageRaw else {

--- a/Rarime/Code/Modules/Home/Views/HomeView.swift
+++ b/Rarime/Code/Modules/Home/Views/HomeView.swift
@@ -71,9 +71,12 @@ struct HomeView: View {
                         showTerms: true,
 
                         passport: passportManager.passport,
-                        onFinish: { _ in
-                            isClaimed = true
-                            isCongratsShown = true
+                        onFinish: { isClaimed in
+                            if isClaimed {
+                                self.isClaimed = isClaimed
+                                self.isCongratsShown = true
+                            }
+                            
                             path.removeLast()
                         },
                         onClose: { path.removeLast() }

--- a/Rarime/Code/Modules/ScanPassport/Views/PassportProofView.swift
+++ b/Rarime/Code/Modules/ScanPassport/Views/PassportProofView.swift
@@ -189,6 +189,7 @@ private struct RevocationNFCScan: View {
                 NFCScanner.scanPassport(
                     mrzViewModel.mrzKey,
                     passportViewModel.revocationChallenge,
+                    false,
                     onCompletion: { result in
                         switch result {
                         case .success(let passport):

--- a/Rarime/Code/Modules/ScanPassport/Views/ScanPassportView.swift
+++ b/Rarime/Code/Modules/ScanPassport/Views/ScanPassportView.swift
@@ -109,7 +109,7 @@ struct ScanPassportView: View {
     return ScanPassportView(
         onComplete: { _ in },
         onClose: {},
-        isImportJson: true
+        isImportJson: false
     )
     .environmentObject(WalletManager())
     .environmentObject(userManager)


### PR DESCRIPTION
# Problems
1. Some users couldn't scan their passports for revocation.
2. Some users couldn't reserve their tokens.
3. Users who received a message that they had already received their tokens would receive a UI message that they received them again.

# Reasons
1. The NFC scanning for revocation didn't use the useExtented mod configuration
2. Users with expired documents can not reverse tokens
3.  Users who already received tokens weren't handled on the closing of the receive tokens view

# Solutions
1. Use the useExtendedMode param for the revocation NFC scanning
2. Add the additional checking for users with expired passports.
3. Add the handling for users who already received their tokens on the closing UI 