### PR TITLE
Fix icon color

### DIFF
--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -2474,7 +2474,7 @@
 			repositoryURL = "git@github.com:gonzalezreal/swift-markdown-ui.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.0;
+				version = 2.4.0;
 			};
 		};
 		560F0C282BD114EE00067054 /* XCRemoteSwiftPackageReference "CodeScanner" */ = {

--- a/Rarime.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rarime.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:gonzalezreal/swift-markdown-ui.git",
       "state" : {
-        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
-        "version" : "2.3.0"
+        "revision" : "55441810c0f678c78ed7e2ebd46dde89228e02fc",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Rarime/Code/Modules/Home/Views/HomeView.swift
+++ b/Rarime/Code/Modules/Home/Views/HomeView.swift
@@ -200,7 +200,7 @@ struct HomeView: View {
             ZStack {
                 Image(Icons.bell)
                     .iconMedium()
-                    .foregroundStyle(.textSecondary)
+                    .foregroundStyle(.textPrimary)
                     .onTapGesture { path.append(.notifications) }
                 if notificationManager.unreadNotificationsCounter > 0 {
                     Text(verbatim: notificationManager.unreadNotificationsCounter.formatted())
@@ -213,7 +213,7 @@ struct HomeView: View {
             }
             Image(Icons.qrCode)
                 .iconMedium()
-                .foregroundStyle(.textSecondary)
+                .foregroundStyle(.textPrimary)
                 .onTapGesture { path.append(.scanQr) }
         }
         .padding(.top, 24)


### PR DESCRIPTION
This pull request includes several updates to the `Rarime` project, focusing on dependency updates and UI enhancements. The most important changes are the version bump for the `swift-markdown-ui` package and the UI color adjustments in the `HomeView`.

Dependency updates:

* [`Rarime.xcodeproj/project.pbxproj`](diffhunk://#diff-f3333f47ec2be24b8ba3dc61d06e8a7d2c0ef29db241fc4e3e63404c2c8844fbL2477-R2477): Updated the `swift-markdown-ui` package version from `2.3.0` to `2.4.0`.
* [`Rarime.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-a4a7a5b828833b68f8b24ccea42fb6fe1f8ee23ce93df2a6ce1ed468da13352bL269-R270): Updated the `swift-markdown-ui` package version from `2.3.0` to `2.4.0` and changed the revision hash.

UI enhancements:

* [`Rarime/Code/Modules/Home/Views/HomeView.swift`](diffhunk://#diff-b3c99114493dff3058322df304e5e099c9fb89ab5c357ca530884b1f5b1427e6L203-R203): Changed the `foregroundStyle` of the bell icon from `.textSecondary` to `.textPrimary`.
* [`Rarime/Code/Modules/Home/Views/HomeView.swift`](diffhunk://#diff-b3c99114493dff3058322df304e5e099c9fb89ab5c357ca530884b1f5b1427e6L216-R216): Changed the `foregroundStyle` of the QR code icon from `.textSecondary` to `.textPrimary`.