### PR TITLE
Add the secp curve family slave/master certificates support. The secp and brainpool curve family support for Active Authentication

### DIFF
--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -231,7 +231,6 @@
 		CE9E82D72BA8917100AAF885 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9E82D62BA8917100AAF885 /* LottieView.swift */; };
 		CEA03F0A2C7C7A17002F218A /* View+IsLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F092C7C7A17002F218A /* View+IsLoading.swift */; };
 		CEA03F0C2C7C9319002F218A /* CreateIdentityIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */; };
-		CEAAF5C52CD2942200C89A23 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAAF5C42CD2942200C89A23 /* Identity.xcframework */; };
 		CEB355892CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355882CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a */; };
 		CEB3558A2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */; };
 		CEB3558B2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */; };
@@ -259,6 +258,7 @@
 		CEDC57922CA2CA0F00F02132 /* MRZCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57912CA2CA0F00F02132 /* MRZCameraManager.swift */; };
 		CEDC57942CA2CA4100F02132 /* CMSampleBuffer+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57932CA2CA4100F02132 /* CMSampleBuffer+Extension.swift */; };
 		CEDC57962CA30A9D00F02132 /* CIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57952CA30A9D00F02132 /* CIImage+Extension.swift */; };
+		CEEBF3142CD4D6E900636924 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEEBF3132CD4D6E800636924 /* Identity.xcframework */; };
 		CEF251382BD6E17800050507 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF251372BD6E17800050507 /* UserManager.swift */; };
 		CEF2513A2BD6E22700050507 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF251392BD6E22700050507 /* User.swift */; };
 		CEF723142BF4BB9000E79198 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF723132BF4BB9000E79198 /* Errors.swift */; };
@@ -510,7 +510,6 @@
 		CE9E82E62BA89CE300AAF885 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		CEA03F092C7C7A17002F218A /* View+IsLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+IsLoading.swift"; sourceTree = "<group>"; };
 		CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIdentityIntroView.swift; sourceTree = "<group>"; };
-		CEAAF5C42CD2942200C89A23 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a; sourceTree = "<group>"; };
 		CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a; sourceTree = "<group>"; };
 		CEB355872CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a; sourceTree = "<group>"; };
@@ -550,6 +549,7 @@
 		CEDC57932CA2CA4100F02132 /* CMSampleBuffer+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMSampleBuffer+Extension.swift"; sourceTree = "<group>"; };
 		CEDC57952CA30A9D00F02132 /* CIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CIImage+Extension.swift"; sourceTree = "<group>"; };
 		CEE3259E2CB7CA6E00468BE4 /* witnesscalc_registerIdentity_1_256_3_5_576_248_NA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = witnesscalc_registerIdentity_1_256_3_5_576_248_NA.h; sourceTree = "<group>"; };
+		CEEBF3132CD4D6E800636924 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEF251372BD6E17800050507 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		CEF251392BD6E22700050507 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		CEF723132BF4BB9000E79198 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -613,7 +613,7 @@
 				CE6BC17D2CBEA96800880287 /* libwitnesscalc_registerIdentity_2_256_3_6_336_264_21_2448_6_2008.a in Frameworks */,
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
-				CEAAF5C52CD2942200C89A23 /* Identity.xcframework in Frameworks */,
+				CEEBF3142CD4D6E900636924 /* Identity.xcframework in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 			);
@@ -1299,7 +1299,7 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEAAF5C42CD2942200C89A23 /* Identity.xcframework */,
+				CEEBF3132CD4D6E800636924 /* Identity.xcframework */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562002BD923B3002D4954 /* prover.h */,
 				CE8FEB5D2C1AFC780008381A /* witnesscalc_auth.h */,

--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -231,11 +231,11 @@
 		CE9E82D72BA8917100AAF885 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9E82D62BA8917100AAF885 /* LottieView.swift */; };
 		CEA03F0A2C7C7A17002F218A /* View+IsLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F092C7C7A17002F218A /* View+IsLoading.swift */; };
 		CEA03F0C2C7C9319002F218A /* CreateIdentityIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */; };
+		CEAAF5BB2CD2436B00C89A23 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */; };
 		CEB355892CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355882CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a */; };
 		CEB3558A2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */; };
 		CEB3558B2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */; };
 		CEB3558C2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355872CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a */; };
-		CEB5A2D02CD0E367000862E3 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB5A2CF2CD0E367000862E3 /* Identity.xcframework */; };
 		CEB91BBE2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB91BBD2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift */; };
 		CEC562032BD923B4002D4954 /* libfr.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC561FB2BD923B3002D4954 /* libfr.a */; };
 		CEC562042BD923B4002D4954 /* librapidsnark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC561FC2BD923B3002D4954 /* librapidsnark.a */; };
@@ -510,6 +510,7 @@
 		CE9E82E62BA89CE300AAF885 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		CEA03F092C7C7A17002F218A /* View+IsLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+IsLoading.swift"; sourceTree = "<group>"; };
 		CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIdentityIntroView.swift; sourceTree = "<group>"; };
+		CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a; sourceTree = "<group>"; };
 		CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a; sourceTree = "<group>"; };
 		CEB355872CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a; sourceTree = "<group>"; };
@@ -518,7 +519,6 @@
 		CEB3558E2CC160FA001EB4F6 /* witnesscalc_registerIdentity_12_256_3_3_336_232_NA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = witnesscalc_registerIdentity_12_256_3_3_336_232_NA.h; sourceTree = "<group>"; };
 		CEB3558F2CC16108001EB4F6 /* witnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = witnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.h; sourceTree = "<group>"; };
 		CEB355902CC16117001EB4F6 /* witnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = witnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.h; sourceTree = "<group>"; };
-		CEB5A2CF2CD0E367000862E3 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEB91BBD2C09BAF4001EECA9 /* NFCPassportModel+getDataGroupsRead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NFCPassportModel+getDataGroupsRead.swift"; sourceTree = "<group>"; };
 		CEC561FB2BD923B3002D4954 /* libfr.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libfr.a; sourceTree = "<group>"; };
 		CEC561FC2BD923B3002D4954 /* librapidsnark.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = librapidsnark.a; sourceTree = "<group>"; };
@@ -613,7 +613,7 @@
 				CE6BC17D2CBEA96800880287 /* libwitnesscalc_registerIdentity_2_256_3_6_336_264_21_2448_6_2008.a in Frameworks */,
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
-				CEB5A2D02CD0E367000862E3 /* Identity.xcframework in Frameworks */,
+				CEAAF5BB2CD2436B00C89A23 /* Identity.xcframework in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 			);
@@ -1299,7 +1299,7 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEB5A2CF2CD0E367000862E3 /* Identity.xcframework */,
+				CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562002BD923B3002D4954 /* prover.h */,
 				CE8FEB5D2C1AFC780008381A /* witnesscalc_auth.h */,

--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -231,7 +231,7 @@
 		CE9E82D72BA8917100AAF885 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9E82D62BA8917100AAF885 /* LottieView.swift */; };
 		CEA03F0A2C7C7A17002F218A /* View+IsLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F092C7C7A17002F218A /* View+IsLoading.swift */; };
 		CEA03F0C2C7C9319002F218A /* CreateIdentityIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */; };
-		CEAAF5BB2CD2436B00C89A23 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */; };
+		CEAAF5C52CD2942200C89A23 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAAF5C42CD2942200C89A23 /* Identity.xcframework */; };
 		CEB355892CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355882CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_12_256_3_3_336_232_NA.a */; };
 		CEB3558A2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */; };
 		CEB3558B2CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */; };
@@ -510,7 +510,7 @@
 		CE9E82E62BA89CE300AAF885 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		CEA03F092C7C7A17002F218A /* View+IsLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+IsLoading.swift"; sourceTree = "<group>"; };
 		CEA03F0B2C7C9319002F218A /* CreateIdentityIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateIdentityIntroView.swift; sourceTree = "<group>"; };
-		CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
+		CEAAF5C42CD2942200C89A23 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEB355852CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_336_232_1_1480_5_296.a; sourceTree = "<group>"; };
 		CEB355862CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_1_256_3_4_600_248_1_1496_3_256.a; sourceTree = "<group>"; };
 		CEB355872CC15FAB001EB4F6 /* libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libwitnesscalc_registerIdentity_11_256_3_3_576_248_1_1184_5_264.a; sourceTree = "<group>"; };
@@ -613,7 +613,7 @@
 				CE6BC17D2CBEA96800880287 /* libwitnesscalc_registerIdentity_2_256_3_6_336_264_21_2448_6_2008.a in Frameworks */,
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
-				CEAAF5BB2CD2436B00C89A23 /* Identity.xcframework in Frameworks */,
+				CEAAF5C52CD2942200C89A23 /* Identity.xcframework in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 			);
@@ -1299,7 +1299,7 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEAAF5BA2CD2436B00C89A23 /* Identity.xcframework */,
+				CEAAF5C42CD2942200C89A23 /* Identity.xcframework */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562002BD923B3002D4954 /* prover.h */,
 				CE8FEB5D2C1AFC780008381A /* witnesscalc_auth.h */,

--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -258,11 +258,11 @@
 		CEDC57922CA2CA0F00F02132 /* MRZCameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57912CA2CA0F00F02132 /* MRZCameraManager.swift */; };
 		CEDC57942CA2CA4100F02132 /* CMSampleBuffer+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57932CA2CA4100F02132 /* CMSampleBuffer+Extension.swift */; };
 		CEDC57962CA30A9D00F02132 /* CIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDC57952CA30A9D00F02132 /* CIImage+Extension.swift */; };
-		CEEBF3142CD4D6E900636924 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEEBF3132CD4D6E800636924 /* Identity.xcframework */; };
 		CEF251382BD6E17800050507 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF251372BD6E17800050507 /* UserManager.swift */; };
 		CEF2513A2BD6E22700050507 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF251392BD6E22700050507 /* User.swift */; };
 		CEF723142BF4BB9000E79198 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF723132BF4BB9000E79198 /* Errors.swift */; };
 		CEF8C7F72BE0DE9700F8E1A4 /* CosmosTransferResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF8C7F62BE0DE9700F8E1A4 /* CosmosTransferResponse.swift */; };
+		CEFBAB1C2CDBA41900EBC0E0 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */; };
 		CEFE5F352CB522A700498F39 /* RegisterIdentityCircuitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F342CB522A700498F39 /* RegisterIdentityCircuitType.swift */; };
 		CEFE5F372CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F362CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift */; };
 		CEFE5F392CB56C8700498F39 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F382CB56C8700498F39 /* CryptoUtils.swift */; };
@@ -549,11 +549,11 @@
 		CEDC57932CA2CA4100F02132 /* CMSampleBuffer+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMSampleBuffer+Extension.swift"; sourceTree = "<group>"; };
 		CEDC57952CA30A9D00F02132 /* CIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CIImage+Extension.swift"; sourceTree = "<group>"; };
 		CEE3259E2CB7CA6E00468BE4 /* witnesscalc_registerIdentity_1_256_3_5_576_248_NA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = witnesscalc_registerIdentity_1_256_3_5_576_248_NA.h; sourceTree = "<group>"; };
-		CEEBF3132CD4D6E800636924 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEF251372BD6E17800050507 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		CEF251392BD6E22700050507 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		CEF723132BF4BB9000E79198 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		CEF8C7F62BE0DE9700F8E1A4 /* CosmosTransferResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosTransferResponse.swift; sourceTree = "<group>"; };
+		CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEFE5F342CB522A700498F39 /* RegisterIdentityCircuitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterIdentityCircuitType.swift; sourceTree = "<group>"; };
 		CEFE5F362CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportRegisterIdentityCircuitSignatureType.swift; sourceTree = "<group>"; };
 		CEFE5F382CB56C8700498F39 /* CryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; };
@@ -613,7 +613,7 @@
 				CE6BC17D2CBEA96800880287 /* libwitnesscalc_registerIdentity_2_256_3_6_336_264_21_2448_6_2008.a in Frameworks */,
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
-				CEEBF3142CD4D6E900636924 /* Identity.xcframework in Frameworks */,
+				CEFBAB1C2CDBA41900EBC0E0 /* Identity.xcframework in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 			);
@@ -1299,7 +1299,7 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEEBF3132CD4D6E800636924 /* Identity.xcframework */,
+				CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562002BD923B3002D4954 /* prover.h */,
 				CE8FEB5D2C1AFC780008381A /* witnesscalc_auth.h */,

--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -262,7 +262,6 @@
 		CEF2513A2BD6E22700050507 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF251392BD6E22700050507 /* User.swift */; };
 		CEF723142BF4BB9000E79198 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF723132BF4BB9000E79198 /* Errors.swift */; };
 		CEF8C7F72BE0DE9700F8E1A4 /* CosmosTransferResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF8C7F62BE0DE9700F8E1A4 /* CosmosTransferResponse.swift */; };
-		CEFBAB1C2CDBA41900EBC0E0 /* Identity.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */; };
 		CEFE5F352CB522A700498F39 /* RegisterIdentityCircuitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F342CB522A700498F39 /* RegisterIdentityCircuitType.swift */; };
 		CEFE5F372CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F362CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift */; };
 		CEFE5F392CB56C8700498F39 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE5F382CB56C8700498F39 /* CryptoUtils.swift */; };
@@ -553,7 +552,6 @@
 		CEF251392BD6E22700050507 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		CEF723132BF4BB9000E79198 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		CEF8C7F62BE0DE9700F8E1A4 /* CosmosTransferResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosTransferResponse.swift; sourceTree = "<group>"; };
-		CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Identity.xcframework; sourceTree = "<group>"; };
 		CEFE5F342CB522A700498F39 /* RegisterIdentityCircuitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterIdentityCircuitType.swift; sourceTree = "<group>"; };
 		CEFE5F362CB5471600498F39 /* SupportRegisterIdentityCircuitSignatureType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportRegisterIdentityCircuitSignatureType.swift; sourceTree = "<group>"; };
 		CEFE5F382CB56C8700498F39 /* CryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; };
@@ -613,7 +611,6 @@
 				CE6BC17D2CBEA96800880287 /* libwitnesscalc_registerIdentity_2_256_3_6_336_264_21_2448_6_2008.a in Frameworks */,
 				CE7210312BD807140043DB7F /* ZipArchive in Frameworks */,
 				560F0C2A2BD114EE00067054 /* CodeScanner in Frameworks */,
-				CEFBAB1C2CDBA41900EBC0E0 /* Identity.xcframework in Frameworks */,
 				CE68BE492BD9B6EA00D92EBB /* Web3PromiseKit in Frameworks */,
 				CEDB9DCC2BFDF60900BCF074 /* libwitnesscalc_queryIdentity.a in Frameworks */,
 			);
@@ -1299,7 +1296,6 @@
 		CEC562122BD92804002D4954 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CEFBAB1B2CDBA41900EBC0E0 /* Identity.xcframework */,
 				CEC561FF2BD923B3002D4954 /* bridge.h */,
 				CEC562002BD923B3002D4954 /* prover.h */,
 				CE8FEB5D2C1AFC780008381A /* witnesscalc_auth.h */,

--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -185,12 +185,7 @@ class UserManager: ObservableObject {
         
         LoggerUtil.common.info("Passport certificate is not registered, registering...")
         
-        let calldata = try IdentityCallDataBuilder().buildRegisterCertificateCalldata(
-            Certificates.ICAO,
-            slavePem: certPem,
-            masterCertificatesBucketname: ConfigManager.shared.certificatesStorage.masterCertificatesBucketname,
-            masterCertificatesFilename: ConfigManager.shared.certificatesStorage.masterCertificatesFilename
-        )
+        let calldata = try IdentityCallDataBuilder().buildRegisterCertificateCalldata(Certificates.ICAO, slavePem: certPem)
         
         let relayer = Relayer(ConfigManager.shared.api.relayerURL)
         let response = try await relayer.register(calldata, ConfigManager.shared.api.registerContractAddress)

--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -122,11 +122,15 @@ class UserManager: ObservableObject {
         
         let proofJson = try JSONEncoder().encode(registerZkProof)
         
+        let sod = try passport.getSod()
+        let ec = try sod.getEncapsulatedContent()
+        
         let calldataBuilder = IdentityCallDataBuilder()
         let calldata = try calldataBuilder.buildRegisterCalldata(
             proofJson,
-            signature: passport.signature,
-            pubKeyPem: passport.getDG15PublicKeyPEM(),
+            aaSignature: passport.signature,
+            aaPubKeyPem: passport.getDG15PublicKeyPEM(),
+            ecSizeInBits: ec.count * 8,
             certificatesRootRaw: masterCertProof.root,
             isRevoked: isRevoked,
             circuitName: registerIdentityCircuitName
@@ -146,11 +150,16 @@ class UserManager: ObservableObject {
         
         let signature = passport.signature
         
+        var sod = try passport.getSod()
+        
+        var ec = try sod.getEncapsulatedContent()
+        
         let calldataBuilder = IdentityCallDataBuilder()
         let calldata = try calldataBuilder.buildRevoceCalldata(
             identityKey,
-            signature: signature,
-            pubKeyPem: passport.getDG15PublicKeyPEM()
+            aaSignature: signature,
+            aaPubKeyPem: passport.getDG15PublicKeyPEM(),
+            ecSizeInBits: ec.count * 8
         )
         
         let relayer = Relayer(ConfigManager.shared.api.relayerURL)

--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -186,7 +186,7 @@ class UserManager: ObservableObject {
         LoggerUtil.common.info("Passport certificate is not registered, registering...")
         
         let calldata = try IdentityCallDataBuilder().buildRegisterCertificateCalldata(
-            ConfigManager.shared.certificatesStorage.icaoCosmosRpc,
+            Certificates.ICAO,
             slavePem: certPem,
             masterCertificatesBucketname: ConfigManager.shared.certificatesStorage.masterCertificatesBucketname,
             masterCertificatesFilename: ConfigManager.shared.certificatesStorage.masterCertificatesFilename


### PR DESCRIPTION
This pull request includes changes to the `Rarime.xcodeproj` project file and the `UserManager` class in `Rarime/Code/Managers/UserManager.swift`. The most important changes include the removal of the `Identity.xcframework` reference from various sections of the project file and updates to the `UserManager` class to handle new data fields from the `passport` object.

Changes to `Rarime.xcodeproj`:

* Removed the `Identity.xcframework` reference from the `Frameworks` section. [[1]](diffhunk://#diff-f3333f47ec2be24b8ba3dc61d06e8a7d2c0ef29db241fc4e3e63404c2c8844fbL238) [[2]](diffhunk://#diff-f3333f47ec2be24b8ba3dc61d06e8a7d2c0ef29db241fc4e3e63404c2c8844fbL521) [[3]](diffhunk://#diff-f3333f47ec2be24b8ba3dc61d06e8a7d2c0ef29db241fc4e3e63404c2c8844fbL616) [[4]](diffhunk://#diff-f3333f47ec2be24b8ba3dc61d06e8a7d2c0ef29db241fc4e3e63404c2c8844fbL1302)

Changes to `UserManager` class:

* Added handling for `sod` and `ec` data fields from the `passport` object in the `buildRegisterCalldata` and `buildRevoceCalldata` methods. [[1]](diffhunk://#diff-10aaae0e01f746b7f8e3d6dfd62723935184932d8d9258e8829ae1460832ec73R125-R133) [[2]](diffhunk://#diff-10aaae0e01f746b7f8e3d6dfd62723935184932d8d9258e8829ae1460832ec73R153-R162)
* Simplified the `buildRegisterCertificateCalldata` method to use a new `Certificates.ICAO` parameter.