### PR TITLE
Handle uniqueness check failure in ProofRequestView and emit error alert

### DIFF
--- a/Rarime/Code/Modules/Main/Views/ExternalRequests/ProofRequestView.swift
+++ b/Rarime/Code/Modules/Main/Views/ExternalRequests/ProofRequestView.swift
@@ -122,12 +122,20 @@ struct ProofRequestView: View {
                     passport: passport,
                     params: proofParamsResponse!.data.attributes
                 )
-                
+
                 let response = try await VerificatorApi.sendProof(
                     url: URL(string: proofParamsResponse!.data.attributes.callbackURL)!,
                     userId: proofParamsResponse!.data.id,
                     proof: proof
                 )
+
+                if response.data.attributes.status == .uniquenessCheckFailed {
+                    AlertManager.shared.emitError(.unknown("Uniqueness check failed"))
+
+                    onDismiss()
+
+                    return
+                }
 
                 if response.data.attributes.status != .verified {
                     throw "Proof status is not verified"


### PR DESCRIPTION
This pull request includes a change to the `ProofRequestView` in the `Rarime/Code/Modules/Main/Views/ExternalRequests/ProofRequestView.swift` file. The change adds an error handling mechanism for a specific status check.

Error handling improvements:

* [`Rarime/Code/Modules/Main/Views/ExternalRequests/ProofRequestView.swift`](diffhunk://#diff-b533ebebe2900a8c79cee83e9646f176867c8c6fb9693bdb160ad7d475d4630bR132-R139): Added a condition to check if `response.data.attributes.status` is `.uniquenessCheckFailed` and emit an error using `AlertManager` before dismissing the view and returning.