### PR TITLE
Extend the circuit naming capabilities

### DIFF
--- a/Rarime.xcodeproj/project.pbxproj
+++ b/Rarime.xcodeproj/project.pbxproj
@@ -2504,7 +2504,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
@@ -2557,7 +2557,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
@@ -2676,7 +2676,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;
@@ -2788,7 +2788,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = Rarilabs.Rarime;

--- a/Rarime/Code/Models/Circuits/RegisterIdentityCircuitType.swift
+++ b/Rarime/Code/Models/Circuits/RegisterIdentityCircuitType.swift
@@ -138,11 +138,11 @@ extension RegisterIdentityCircuitType {
     }
 
     enum CircuitKeySizeType {
-        case B1024, B2048, B4096, B256, B320, B192
+        case B1024, B2048, B3072, B4096, B160, B192, B224, B256, B320, B384, B512
     }
 
     enum CircuitExponentType {
-        case E3, E65537
+        case E3, E65537, E37187
     }
 
     enum CircuitSaltType {
@@ -150,11 +150,12 @@ extension RegisterIdentityCircuitType {
     }
 
     enum CircuitCurveType {
-        case SECP256R1, BRAINPOOLP256R1, BRAINPOOLP320R1, SECP192R1
+        case SECP160R1, SECP192R1, SECP224R1, SECP256R1, SECP384R1, SECP512R1
+        case BRAINPOOLP160R1, BRAINPOOLP192R1, BRAINPOOLP224R1, BRAINPOOLP256R1, BRAINPOOLP320R1, BRAINPOOLP384R1, BRAINPOOLP512R1
     }
 
     enum CircuitHashAlgorithmType {
-        case HA256, HA384, HA160
+        case HA160, HA192, HA224, HA256, HA384, HA512
     }
 }
 
@@ -277,14 +278,24 @@ extension Passport {
             return .B1024
         case 2048:
             return .B2048
+        case 3072:
+            return .B3072
         case 4096:
             return .B4096
+        case 160:
+            return .B160
+        case 192:
+            return .B192
+        case 224:
+            return .B224
         case 256:
             return .B256
         case 320:
             return .B320
-        case 192:
-            return .B192
+        case 384:
+            return .B384
+        case 512:
+            return .B512
         default:
             return nil
         }
@@ -297,6 +308,8 @@ extension Passport {
 
         if exponentBN.cmp(BN(3)) == 0 {
             return .E3
+        } else if exponentBN.cmp(BN(37187)) == 0 {
+            return .E37187
         } else if exponentBN.cmp(BN(65537)) == 0 {
             return .E65537
         } else {
@@ -374,14 +387,32 @@ extension Passport {
         }
 
         switch curveName {
-        case "secp256r1", "prime256v1":
-            return .SECP256R1
-        case "secp192r1", "prime192v1":
+        case "secp160r1", "prime160r1", "P-160":
+            return .SECP160R1
+        case "secp192r1", "prime192v1", "P-192":
             return .SECP192R1
+        case "secp224r1", "prime224v1", "P-224":
+            return .SECP224R1
+        case "secp256r1", "prime256v1", "P-256":
+            return .SECP256R1
+        case "secp384r1", "prime384v1", "P-384":
+            return .SECP384R1
+        case "secp521r1", "prime521v1", "P-521":
+            return .SECP512R1
+        case "brainpoolP160r1":
+            return .BRAINPOOLP160R1
+        case "brainpoolP192r1":
+            return .BRAINPOOLP192R1
+        case "brainpoolP224r1":
+            return .BRAINPOOLP224R1
         case "brainpoolP256r1":
             return .BRAINPOOLP256R1
         case "brainpoolP320r1":
             return .BRAINPOOLP256R1
+        case "brainpoolP384r1":
+            return .BRAINPOOLP384R1
+        case "brainpoolP512r1":
+            return .BRAINPOOLP512R1
         default:
             return nil
         }

--- a/Rarime/Code/Models/Circuits/SupportRegisterIdentityCircuitSignatureType.swift
+++ b/Rarime/Code/Models/Circuits/SupportRegisterIdentityCircuitSignatureType.swift
@@ -6,18 +6,23 @@ class SupportRegisterIdentityCircuitSignatureType {
         .init(staticId: 1, algorithm: .RSA, keySize: .B2048, exponent: .E65537, salt: nil, curve: nil, hashAlgorithm: .HA256),
         .init(staticId: 2, algorithm: .RSA, keySize: .B4096, exponent: .E65537, salt: nil, curve: nil, hashAlgorithm: .HA256),
         .init(staticId: 3, algorithm: .RSA, keySize: .B2048, exponent: .E65537, salt: nil, curve: nil, hashAlgorithm: .HA160),
+        .init(staticId: 4, algorithm: .RSA, keySize: .B3072, exponent: .E37187, salt: nil, curve: nil, hashAlgorithm: .HA160),
 
         // RSAPSS
         .init(staticId: 10, algorithm: .RSAPSS, keySize: .B2048, exponent: .E3, salt: .S32, curve: nil, hashAlgorithm: .HA256),
         .init(staticId: 11, algorithm: .RSAPSS, keySize: .B2048, exponent: .E65537, salt: .S32, curve: nil, hashAlgorithm: .HA256),
         .init(staticId: 12, algorithm: .RSAPSS, keySize: .B2048, exponent: .E65537, salt: .S64, curve: nil, hashAlgorithm: .HA256),
         .init(staticId: 13, algorithm: .RSAPSS, keySize: .B2048, exponent: .E65537, salt: .S48, curve: nil, hashAlgorithm: .HA384),
+        .init(staticId: 14, algorithm: .RSAPSS, keySize: .B3072, exponent: .E65537, salt: .S32, curve: nil, hashAlgorithm: .HA256),
+        .init(staticId: 15, algorithm: .RSAPSS, keySize: .B2048, exponent: .E65537, salt: .S64, curve: nil, hashAlgorithm: .HA512),
 
         // ECDSA
         .init(staticId: 20, algorithm: .ECDSA, keySize: .B256, exponent: nil, salt: nil, curve: .SECP256R1, hashAlgorithm: .HA256),
         .init(staticId: 21, algorithm: .ECDSA, keySize: .B256, exponent: nil, salt: nil, curve: .BRAINPOOLP256R1, hashAlgorithm: .HA256),
         .init(staticId: 22, algorithm: .ECDSA, keySize: .B320, exponent: nil, salt: nil, curve: .BRAINPOOLP320R1, hashAlgorithm: .HA256),
         .init(staticId: 23, algorithm: .ECDSA, keySize: .B192, exponent: nil, salt: nil, curve: .SECP192R1, hashAlgorithm: .HA160),
+        .init(staticId: 24, algorithm: .ECDSA, keySize: .B224, exponent: nil, salt: nil, curve: .SECP224R1, hashAlgorithm: .HA224),
+        .init(staticId: 25, algorithm: .ECDSA, keySize: .B384, exponent: nil, salt: nil, curve: .BRAINPOOLP384R1, hashAlgorithm: .HA384),
     ]
 
     static func getSupportedSignatureTypeId(_ type: RegisterIdentityCircuitType.CircuitSignatureType) -> UInt? {


### PR DESCRIPTION
This pull request to `Rarime/Code/Models/Circuits/RegisterIdentityCircuitType.swift` and `Rarime/Code/Models/Circuits/SupportRegisterIdentityCircuitSignatureType.swift` includes several enhancements to support additional cryptographic parameters. The most important changes include expanding the key size, exponent, curve, and hash algorithm types, as well as updating the `Passport` extension to handle these new types.

Enhancements to cryptographic parameters:

* [`Rarime/Code/Models/Circuits/RegisterIdentityCircuitType.swift`](diffhunk://#diff-c32ba07420149ba5682b191b5e4a49ba3b5f8914008eadb80b58526260abf4ccL141-R158): Expanded `CircuitKeySizeType`, `CircuitExponentType`, `CircuitCurveType`, and `CircuitHashAlgorithmType` enums to support additional cryptographic parameters.
* [`Rarime/Code/Models/Circuits/RegisterIdentityCircuitType.swift`](diffhunk://#diff-c32ba07420149ba5682b191b5e4a49ba3b5f8914008eadb80b58526260abf4ccR281-R298): Updated the `Passport` extension to handle the new key sizes, exponents, and curves. [[1]](diffhunk://#diff-c32ba07420149ba5682b191b5e4a49ba3b5f8914008eadb80b58526260abf4ccR281-R298) [[2]](diffhunk://#diff-c32ba07420149ba5682b191b5e4a49ba3b5f8914008eadb80b58526260abf4ccR311-R312) [[3]](diffhunk://#diff-c32ba07420149ba5682b191b5e4a49ba3b5f8914008eadb80b58526260abf4ccL377-R415)

Support for new signature types:

* [`Rarime/Code/Models/Circuits/SupportRegisterIdentityCircuitSignatureType.swift`](diffhunk://#diff-a4c482f2b62e55abc0a92733dd3a3d233caea602efb85d7f48cc8cb93b240eb4R9-R25): Added new entries to support additional RSA and ECDSA signature types with the newly added cryptographic parameters.