### PR TITLE
Minor Typo Fixes in UserManager and MainViewLayout

### DIFF
--- a/Rarime/Code/Managers/UserManager.swift
+++ b/Rarime/Code/Managers/UserManager.swift
@@ -597,7 +597,7 @@ class UserManager: ObservableObject {
     }
     
     func generateNullifierForEvent(_ eventId: String) throws -> String {
-        guard let user else { throw "User is not initalized" }
+        guard let user else { throw "User is not initialized" }
         
         var error: NSError?
         let nullifier = user.profile.calculateEventNullifierHex(eventId, error: &error)

--- a/Rarime/Code/Modules/Main/Views/MainViewLayout.swift
+++ b/Rarime/Code/Modules/Main/Views/MainViewLayout.swift
@@ -12,7 +12,7 @@ struct MainViewLayout<Content: View>: View {
                 selectedTab: $mainViewModel.selectedTab,
                 isQrCodeScanSheetShown: $mainViewModel.isQrCodeScanSheetShown
             )
-            // TODO: move to extenstion with blur
+            // TODO: move to extension with blur
             .background {
                 ZStack {
                     Color.bgBlur


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in two files:
- In `UserManager.swift`, the error message "User is not initalized" was corrected to "User is not initialized".
- In `MainViewLayout.swift`, the comment "move to extenstion with blur" was corrected to "move to extension with blur".

No functional changes were made; these are purely textual improvements for clarity and correctness.
